### PR TITLE
build: compile with -D_XOPEN_SOURCE=600 and -Wextra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 BLDDIR = build
 TARGET = rtsprelay
 
-CFLAGS = -g -O0 --std=c99 -Wall
+CFLAGS = -g -O1 --std=c99 -D_XOPEN_SOURCE=600
+CFLAGS += -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
 LIBS =
 
 PKGS = gstreamer-1.0 gstreamer-app-1.0 gstreamer-rtsp-1.0 gstreamer-rtsp-server-1.0


### PR DESCRIPTION
strdup() technically needs _XOPEN_SOURCE >= 500

also need some exceptions from -Wextra (some unused stuff is normal)

also change optimization from level 0 to level 1
 - just some easy optimizations, shouldn't be too confusing :)

fixes #3 
cc @jayridge @protonpopsicle