### PR TITLE
make sure stdout is line buffered

### DIFF
--- a/rtsprelay.c
+++ b/rtsprelay.c
@@ -282,6 +282,9 @@ int main(int argc, char **argv)
 	GOptionContext *optctx;
 	GError *error = NULL;
 
+	// stdout line buffered even if not connected to terminal
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
 	optctx = g_option_context_new("RTSP Relay\n\n");
 
 	g_option_context_add_main_entries(optctx, entries, NULL);


### PR DESCRIPTION
When running in a typical docker container, stdout is not connected
to a terminal, so it is block-buffered by default, and log messages
are very delayed.

can be tested like:

```
$ ./build/rtsprelay 2>&1 | cat &
[1] 16504
$ pkill -e -f build/rtsprelay
rtsprelay killed (pid 16503)
listening at rtsp://0.0.0.0:8554
received signal - quitting event loop
exiting...
```

(That was the behavior before this change - "listening at" wasn't printed when the process started.)

An alternative solution is to change all the `printf(...)` to `fprintf(stderr, ...)` because `stderr` is unbuffered by default.

I'm not going crazy with rtsprelay, just some tweaks here and there, in this case to get my log messages :)